### PR TITLE
Drop special-case support for missing keys

### DIFF
--- a/src/higher-order-decoders.ts
+++ b/src/higher-order-decoders.ts
@@ -6,23 +6,23 @@ import { tag } from './utils';
 type evalOver<t> = t extends unknown ? decodeType<t> : never;
 type getSumOfArray<arr> = arr extends (infer elements)[] ? elements : never;
 
-export const union = <decoders extends Decoder<unknown>[]>(
-  ...decoders: decoders
-) => (value: Pojo): evalOver<getSumOfArray<decoders>> => {
-  if (decoders.length === 0) {
-    throw `Could not match any of the union cases`;
-  }
-  const [decoder, ...rest] = decoders;
-  try {
-    return decode(decoder as any)(value) as any;
-  } catch (messageFromThisDecoder) {
-    try {
-      return union(...(rest as any))(value) as any;
-    } catch (message) {
-      throw `${messageFromThisDecoder}\n${message}`;
+export const union =
+  <decoders extends Decoder<unknown>[]>(...decoders: decoders) =>
+  (value: Pojo): evalOver<getSumOfArray<decoders>> => {
+    if (decoders.length === 0) {
+      throw `Could not match any of the union cases`;
     }
-  }
-};
+    const [decoder, ...rest] = decoders;
+    try {
+      return decode(decoder as any)(value) as any;
+    } catch (messageFromThisDecoder) {
+      try {
+        return union(...(rest as any))(value) as any;
+      } catch (message) {
+        throw `${messageFromThisDecoder}\n${message}`;
+      }
+    }
+  };
 
 export const nullable = <T extends Decoder<unknown>>(
   decoder: T,
@@ -66,46 +66,52 @@ export function array<D extends Decoder<unknown>>(
   };
 }
 
-export const set = <D extends Decoder<unknown>>(
-  decoder: D,
-): DecoderFunction<Set<decodeType<D>>> => (list: Pojo) => {
-  try {
-    return new Set(decode(array(decoder))(list));
-  } catch (message) {
-    throw message + `\nand can therefore not be parsed as a set`;
-  }
-};
-
-export const map = <K, D extends Decoder<unknown>>(
-  decoder: D,
-  key: (x: decodeType<D>) => K,
-): DecoderFunction<Map<K, decodeType<D>>> => (listOfObjects: Pojo) => {
-  try {
-    const parsedObjects = decode(array(decoder))(listOfObjects);
-    const map = new Map(parsedObjects.map((value) => [key(value), value]));
-    if (parsedObjects.length !== map.size) {
-      console.warn(
-        `Probable duplicate key in map: List \`${parsedObjects}\` isn't the same size as the parsed \`${map}\``,
-      );
-    }
-    return map;
-  } catch (message) {
-    throw message + `\nand can therefore not be parsed as a map`;
-  }
-};
-
-export const dict = <D extends Decoder<unknown>>(
-  decoder: D,
-): DecoderFunction<Map<string, decodeType<D>>> => (map: Pojo) => {
-  if (!isPojoObject(map)) {
-    throw `Value \`${map}\` is not an object and can therefore not be parsed as a map`;
-  }
-  const decodedPairs = Object.entries(map).map(([key, value]) => {
+export const set =
+  <D extends Decoder<unknown>>(
+    decoder: D,
+  ): DecoderFunction<Set<decodeType<D>>> =>
+  (list: Pojo) => {
     try {
-      return [key, decode(decoder)(value)] as [string, decodeType<D>];
+      return new Set(decode(array(decoder))(list));
     } catch (message) {
-      throw message + `\nwhen decoding the key \`${key}\` in map \`${map}\``;
+      throw message + `\nand can therefore not be parsed as a set`;
     }
-  });
-  return new Map(decodedPairs);
-};
+  };
+
+export const map =
+  <K, D extends Decoder<unknown>>(
+    decoder: D,
+    key: (x: decodeType<D>) => K,
+  ): DecoderFunction<Map<K, decodeType<D>>> =>
+  (listOfObjects: Pojo) => {
+    try {
+      const parsedObjects = decode(array(decoder))(listOfObjects);
+      const map = new Map(parsedObjects.map((value) => [key(value), value]));
+      if (parsedObjects.length !== map.size) {
+        console.warn(
+          `Probable duplicate key in map: List \`${parsedObjects}\` isn't the same size as the parsed \`${map}\``,
+        );
+      }
+      return map;
+    } catch (message) {
+      throw message + `\nand can therefore not be parsed as a map`;
+    }
+  };
+
+export const dict =
+  <D extends Decoder<unknown>>(
+    decoder: D,
+  ): DecoderFunction<Map<string, decodeType<D>>> =>
+  (map: Pojo) => {
+    if (!isPojoObject(map)) {
+      throw `Value \`${map}\` is not an object and can therefore not be parsed as a map`;
+    }
+    const decodedPairs = Object.entries(map).map(([key, value]) => {
+      try {
+        return [key, decode(decoder)(value)] as [string, decodeType<D>];
+      } catch (message) {
+        throw message + `\nwhen decoding the key \`${key}\` in map \`${map}\``;
+      }
+    });
+    return new Map(decodedPairs);
+  };

--- a/src/higher-order-decoders.ts
+++ b/src/higher-order-decoders.ts
@@ -30,14 +30,9 @@ export const nullable = <T extends Decoder<unknown>>(
   return union(nil, decoder as any);
 };
 
-export const optionalDecoder: unique symbol = Symbol('optional-decoder');
 export const optional = <T extends Decoder<unknown>>(
   decoder: T,
-): DecoderFunction<decodeType<T> | undefined> => {
-  const _optionDecoder = union(undef, decoder as any);
-  tag(_optionDecoder, optionalDecoder);
-  return _optionDecoder;
-};
+): DecoderFunction<decodeType<T> | undefined> => union(undef, decoder as any);
 
 export function array<D extends Decoder<unknown>>(
   decoder: D,

--- a/src/literal-decoders.ts
+++ b/src/literal-decoders.ts
@@ -1,4 +1,3 @@
-import { optionalDecoder } from './higher-order-decoders';
 import { isPojoObject, Pojo } from './pojo';
 import {
   decodeType,
@@ -72,12 +71,6 @@ export const record =
       .map(([key, decoder]: [string, any]) => {
         if (decoder[fieldDecoder] === true) {
           return [key, decode(decoder)(value)];
-        }
-        if (!value.hasOwnProperty(key)) {
-          if ((decoder as any)[optionalDecoder]) {
-            return [key, undefined];
-          }
-          throw `Cannot find key \`${key}\` in \`${JSON.stringify(value)}\``;
         }
         try {
           const jsonvalue = value[key];

--- a/src/literal-decoders.ts
+++ b/src/literal-decoders.ts
@@ -9,34 +9,36 @@ import {
 } from './types';
 import { tag } from './utils';
 
-export const literal = <p extends JsonLiteralForm>(
-  literal: p,
-): DecoderFunction<p> => (value: Pojo) => {
-  if (literal !== value) {
-    throw `The value \`${JSON.stringify(
-      value,
-    )}\` is not the literal \`${JSON.stringify(literal)}\``;
-  }
-  return literal;
-};
+export const literal =
+  <p extends JsonLiteralForm>(literal: p): DecoderFunction<p> =>
+  (value: Pojo) => {
+    if (literal !== value) {
+      throw `The value \`${JSON.stringify(
+        value,
+      )}\` is not the literal \`${JSON.stringify(literal)}\``;
+    }
+    return literal;
+  };
 
-export const tuple = <A extends Decoder<unknown>, B extends Decoder<unknown>>(
-  decoderA: A,
-  decoderB: B,
-): DecoderFunction<[decodeType<A>, decodeType<B>]> => (value: Pojo) => {
-  if (!Array.isArray(value)) {
-    throw `The value \`${JSON.stringify(
-      value,
-    )}\` is not a list and can therefore not be parsed as a tuple`;
-  }
-  if (value.length !== 2) {
-    throw `The array \`${JSON.stringify(
-      value,
-    )}\` is not the proper length for a tuple`;
-  }
-  const [a, b] = value;
-  return [decode(decoderA as any)(a), decode(decoderB as any)(b)];
-};
+export const tuple =
+  <A extends Decoder<unknown>, B extends Decoder<unknown>>(
+    decoderA: A,
+    decoderB: B,
+  ): DecoderFunction<[decodeType<A>, decodeType<B>]> =>
+  (value: Pojo) => {
+    if (!Array.isArray(value)) {
+      throw `The value \`${JSON.stringify(
+        value,
+      )}\` is not a list and can therefore not be parsed as a tuple`;
+    }
+    if (value.length !== 2) {
+      throw `The array \`${JSON.stringify(
+        value,
+      )}\` is not the proper length for a tuple`;
+    }
+    const [a, b] = value;
+    return [decode(decoderA as any)(a), decode(decoderB as any)(b)];
+  };
 
 export const fieldDecoder: unique symbol = Symbol('field-decoder');
 export const fields = <T extends { [key: string]: Decoder<unknown> }, U>(
@@ -58,34 +60,36 @@ export const field = <T>(
   return fields({ [key]: decoder }, (x: any) => x[key]);
 };
 
-export const record = <schema extends { [key: string]: Decoder<unknown> }>(
-  s: schema,
-): DecoderFunction<decodeType<schema>> => (value: Pojo) => {
-  if (!isPojoObject(value)) {
-    throw `Value \`${value}\` is not of type \`object\` but rather \`${typeof value}\``;
-  }
-  return Object.entries(s)
-    .map(([key, decoder]: [string, any]) => {
-      if (decoder[fieldDecoder] === true) {
-        return [key, decode(decoder)(value)];
-      }
-      if (!value.hasOwnProperty(key)) {
-        if ((decoder as any)[optionalDecoder]) {
-          return [key, undefined];
+export const record =
+  <schema extends { [key: string]: Decoder<unknown> }>(
+    s: schema,
+  ): DecoderFunction<decodeType<schema>> =>
+  (value: Pojo) => {
+    if (!isPojoObject(value)) {
+      throw `Value \`${value}\` is not of type \`object\` but rather \`${typeof value}\``;
+    }
+    return Object.entries(s)
+      .map(([key, decoder]: [string, any]) => {
+        if (decoder[fieldDecoder] === true) {
+          return [key, decode(decoder)(value)];
         }
-        throw `Cannot find key \`${key}\` in \`${JSON.stringify(value)}\``;
-      }
-      try {
-        const jsonvalue = value[key];
-        return [key, decode(decoder)(jsonvalue)];
-      } catch (message) {
-        throw (
-          message +
-          `\nwhen trying to decode the key \`${key}\` in \`${JSON.stringify(
-            value,
-          )}\``
-        );
-      }
-    })
-    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
-};
+        if (!value.hasOwnProperty(key)) {
+          if ((decoder as any)[optionalDecoder]) {
+            return [key, undefined];
+          }
+          throw `Cannot find key \`${key}\` in \`${JSON.stringify(value)}\``;
+        }
+        try {
+          const jsonvalue = value[key];
+          return [key, decode(decoder)(jsonvalue)];
+        } catch (message) {
+          throw (
+            message +
+            `\nwhen trying to decode the key \`${key}\` in \`${JSON.stringify(
+              value,
+            )}\``
+          );
+        }
+      })
+      .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+  };


### PR DESCRIPTION
See #4 for longer discussion and rationale.

I’ve also added a commit that reformats the sources with Prettier – is my Prettier configuration wrong, or were the sources not completely formatted before? (We can drop this part if there’s something off with my Prettier.)