### PR TITLE
Add intersection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ const userDecoder = record({
 
 Union takes an arbitrary number of parameters.
 
+Similarly, you can use something like `intersection({email: string}, userDecoder)` to get a decoder for `{email: string} & user`, the subtype of users that also have an e-mail address.
+
 Lastly we can add some more stuff, and if you wish to fetch a list of your users, do it like the following.
 
 ```typescript

--- a/src/higher-order-decoders.ts
+++ b/src/higher-order-decoders.ts
@@ -24,6 +24,48 @@ export const union =
     }
   };
 
+// intersectUnion<a | b> = a & b
+type intersectUnion<U> = (U extends unknown ? ((_: U) => void) : never) extends ((_: infer I) => void) ? I : never;
+
+// asObject<[a, b]> = { 0: {_: a}, 1: {_: b} }
+type asObject<T extends unknown[]> = {[K in Exclude<keyof T, keyof []>]: {_: decodeType<T[K]>}};
+
+// values<{0: a, 1: b}> = a | b
+type values<T> = T[keyof T];
+
+// fromObject {_: a} = a
+type fromObject<T> = T extends {_: infer V} ? V : never;
+
+// combine helpers to get an intersection of all the item types
+type getProductOfDecoderArray<arr extends Decoder<unknown>[]> = fromObject<intersectUnion<values<asObject<arr>>>>;
+
+// NB: if multiple cases create properties with identical keys, only the last one is kept
+export const intersection =
+  <decoders extends Decoder<unknown>[]>(...decoders: decoders) =>
+    (value: Pojo): getProductOfDecoderArray<decoders> => {
+      const errors: any[] = [];
+      const results: any[] = [];
+      for (const decoder of decoders) {
+        try {
+          results.push(decode(decoder)(value));
+        } catch (message) {
+          errors.push(message);
+        }
+      }
+      if (errors.length === 0) {
+        // When not all cases are objects, the static type checking of the
+        // intersection should ensure that we can safely return just the
+        // result of the last case
+        return results.some(res => typeof res !== 'object')
+          ? results[results.length - 1]
+          : results.reduce((acc, val) => ({...acc, ...val}), {});
+      } else {
+        errors.push(`Could not match all of the intersection cases`);
+        throw errors.join('\n');
+      }
+    };
+
+
 export const nullable = <T extends Decoder<unknown>>(
   decoder: T,
 ): DecoderFunction<decodeType<T> | null> => {

--- a/src/higher-order-decoders.ts
+++ b/src/higher-order-decoders.ts
@@ -87,6 +87,14 @@ const combineResults = <A, B>(a: A, b: B): A & B => {
   } else if (jsType === 'function') {
     throw `Combining functions in intersections is not supported`
   } else if (jsType === 'object') {
+    if ([a, b].some(x => x === null)) {
+      const nonNull = [a, b].find(x => x !== null);
+      if (nonNull !== undefined) {
+        throw `Cannot intersect null with non-null value ${nonNull}`;
+      } else {
+        return null as any;
+      }
+    }
     validatePrototype(a);
     validatePrototype(b);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { decode, decodeType, Decoder, DecoderFunction } from './types';
 export { tuple, literal, record, field, fields } from './literal-decoders';
 export {
   union,
+  intersection,
   optional,
   array,
   set,

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -9,9 +9,11 @@ import {
   string,
   undef,
   union,
+  intersection,
   array,
   literal,
   tuple,
+  decode,
 } from '../src';
 
 let n = 0;
@@ -24,6 +26,8 @@ type rec_t = {
   f: string;
   option: string | undefined;
   list_of_stuff: (string | boolean)[];
+  intersect:
+    ({a: number} | {a: string, b: number}) & {c: boolean, a: number | 'foo'}
 };
 const rec_decoder = record({
   data: string,
@@ -32,6 +36,10 @@ const rec_decoder = record({
   f: fields({ data: string, value: number }, ({ data, value }) => data + value),
   option: optional(string),
   list_of_stuff: array(union(string, boolean)),
+  intersect: intersection(
+    union({a: number}, {a: string, b: number}),
+    {c: boolean, a: union(number, decode('foo'))},
+  ),
 });
 expectAssignable<Decoder<rec_t>>(rec_decoder);
 expectType<rec_t>(
@@ -40,11 +48,15 @@ expectType<rec_t>(
     value: 0,
     rec: { more: true },
     option: 'yes',
+    intersect: {a: 'foo'},
   }),
 );
 
 let union_decoder = union(string, number, record({}));
 expectType<string | number | {}>(union_decoder('test'));
+
+let intersection_decoder = intersection({a: string}, {a: decode('foo'), b: number})
+expectType<{a: 'foo'}>(intersection_decoder({a: 'foo'}))
 
 let optional_decoder = optional(union(string, number));
 expectType<string | number | undefined>(optional_decoder(''));

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -55,8 +55,9 @@ expectType<rec_t>(
 let union_decoder = union(string, number, record({}));
 expectType<string | number | {}>(union_decoder('test'));
 
-let intersection_decoder = intersection({a: string}, {a: decode('foo'), b: number})
-expectType<{a: 'foo'}>(intersection_decoder({a: 'foo'}))
+let intersection_decoder = intersection({a: string}, {a: literal('foo'), b: number})
+expectAssignable<{ a: 'foo'; b: number }>(intersection_decoder({a: 'foo'}))
+expectAssignable<{ a: 'foo' }>(intersection_decoder({a: 'foo'}))
 
 let optional_decoder = optional(union(string, number));
 expectType<string | number | undefined>(optional_decoder(''));

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -14,6 +14,7 @@ import {
   literal,
   tuple,
   decode,
+  nullable,
 } from '../src';
 
 let n = 0;
@@ -60,6 +61,8 @@ expectAssignable<{ a: 'foo'; b: number }>(intersection_decoder({a: 'foo'}))
 expectAssignable<{ a: 'foo' }>(intersection_decoder({a: 'foo'}))
 
 expectAssignable<{ a: string, b: number }>(intersection({ a: string }, { b: number })({}))
+expectAssignable<number | undefined>(intersection(optional(number), optional(number))(null))
+expectAssignable<number | null>(intersection(nullable(number), nullable(number))(null))
 
 let optional_decoder = optional(union(string, number));
 expectType<string | number | undefined>(optional_decoder(''));

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -48,7 +48,7 @@ expectType<rec_t>(
     value: 0,
     rec: { more: true },
     option: 'yes',
-    intersect: {a: 'foo'},
+    intersect: { a: 'foo' },
   }),
 );
 
@@ -58,6 +58,8 @@ expectType<string | number | {}>(union_decoder('test'));
 let intersection_decoder = intersection({a: string}, {a: literal('foo'), b: number})
 expectAssignable<{ a: 'foo'; b: number }>(intersection_decoder({a: 'foo'}))
 expectAssignable<{ a: 'foo' }>(intersection_decoder({a: 'foo'}))
+
+expectAssignable<{ a: string, b: number }>(intersection({ a: string }, { b: number })({}))
 
 let optional_decoder = optional(union(string, number));
 expectType<string | number | undefined>(optional_decoder(''));

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,6 +19,7 @@ import {
   Pojo,
   Decoder,
   decode,
+  intersection,
 } from '../src';
 
 test('everything', () => {
@@ -77,6 +78,7 @@ test('everything', () => {
     secondAddrese: optional({ city: string, option: optional(number) }),
     ageAndReputation: [number, string],
     discriminatedUnion,
+    intersection: intersection(discriminatedUnion, {extraData: string}),
     message,
     uni: union('uni', { lol: string }),
     likes: array([literal('likt'), number]),
@@ -103,6 +105,7 @@ test('everything', () => {
     dict: { somestuff: 'lol', morestuff: 7 },
     message: ['something-else', { somestuff: 'a' }],
     discriminatedUnion: { discriminant: 'two', data: '2' },
+    intersection: {discriminant: 'one', extraData: 'hiya'},
     address: { city: 'asdf' },
     secondAddrese: { city: 'secondcity' },
     uni: 'uni',
@@ -138,6 +141,7 @@ test('everything', () => {
     ]),
     message: ['something-else', { somestuff: 'a' }],
     discriminatedUnion: { discriminant: 'two', data: '2' },
+    intersection: { discriminant: 'one', extraData: 'hiya' },
     address: { city: 'asdf' },
     secondAddrese: { city: 'secondcity', option: undefined },
     employeeIdentifier2: 'asdfasd:2',

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -160,33 +160,6 @@ test('deep intersection', () => {
   expect(() => decoder({a: 'foo', b: {c: 42, d: false, f: null}, e: {}, h: 'discard'})).toThrow();
 })
 
-test('class intersection', () => {
-  class A {
-    one() {
-      return 1
-    }
-    // This would fail, since it's not part of the prototype, but rather an
-    // object property, and thus not the same reference on different objects:
-    // two = () => 2;
-  }
-  class B extends A {
-    four = 4;
-  }
-  class C extends A {
-    three() {
-      return 3;
-    }
-  }
-
-  const decoder = intersection(
-    _ => new B(),
-    _ => new C(),
-  )
-
-  const decoded = decoder('discard');
-  expect<number>(decoded.one() + decoded.three() + decoded.four).toEqual(8);
-})
-
 test('decode string', () => {
   const l1: 'a' = 'a' as const;
 

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -579,6 +579,8 @@ test('intersection of objects is mixins/multi-inheritance', () => {
   const intersect_decoder = intersection({ a: string }, { b: number });
 
   expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(intersect_decoder(test_value).a).toEqual(test_value.a);
+  expect(intersect_decoder(test_value).b).toEqual(test_value.b);
   expect(() => intersect_decoder({ a: '' })).toThrow()
   expect(() => intersect_decoder({ b: 0 })).toThrow()
 });
@@ -590,9 +592,11 @@ test('intersection of empty object', () => {
   const intersect_decoder = intersection({}, { a: string });
 
   expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(intersect_decoder(test_value).a).toEqual(test_value.a);
   expect(intersect_decoder({ a: '' })).toEqual({ a: '' })
   expect(() => intersect_decoder({ a: 0 })).toThrow()
   expect(() => intersect_decoder({ b: '' })).toThrow()
+
 });
 
 test('intersection of arrays', () => {
@@ -619,6 +623,25 @@ test('intersection of tuple and array', () => {
   expect(() => intersect_decoder({ a: '' })).toThrow()
   expect(() => intersect_decoder({ b: 0 })).toThrow()
 });
+
+/*
+test('intersection of compatible tuples', () => {
+  
+  const test_value: [ {a: string; b: number}, number] = [ { a: '1', b: 2 }, 3 ]
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection([ { a: string }, number ], [ { b: number }, number ]);
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value)
+  expect(intersect_decoder(test_value)['0'].a).toEqual(test_value['0']['a'])
+  expect(intersect_decoder(test_value)['0'].b).toEqual(test_value['0']['b'])
+  expect(() => intersect_decoder([])).toThrow()
+  expect(() => intersect_decoder([ 1, 2 ])).toThrow()
+  expect(() => intersect_decoder([ '1', 2 ])).toThrow()
+  expect(() => intersect_decoder('')).toThrow()
+  expect(() => intersect_decoder(0)).toThrow()
+});
+*/
 
 test('intersection of incompatible tuples', () => {
 

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -611,6 +611,20 @@ test('intersection of arrays', () => {
   expect(() => intersect_decoder({ b: 0 })).toThrow()
 });
 
+/*
+test('intersection of arrays of objects', () => {
+  const test_value = [ { a: '0', b: 1 }, { a: '2', b: 3 } ];
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection(array({ a: string }), array({ b: number }));
+
+  expect<intersection>(intersect_decoder([])).toEqual([]);
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(intersect_decoder(test_value).map(x => x.a)).toEqual([ '0', '2' ]);
+  expect(intersect_decoder(test_value).map(x => x.b)).toEqual([ 1, 3 ]);
+});
+*/
+
 test('intersection of tuple and array', () => {
   const test_value = [ 1, 2 ]
 

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -625,19 +625,17 @@ test('intersection of arrays', () => {
   expect(() => intersect_decoder({ b: 0 })).toThrow()
 });
 
-/*
-test('intersection of arrays of objects', () => {
-  const test_value = [ { a: '0', b: 1 }, { a: '2', b: 3 } ];
+test('intersection of objects of objects', () => {
+  const test_value = { x: { a: 'a', b: 2 }, y: 'false', z: true }
 
   type intersection = decodeType<typeof intersect_decoder>;
-  const intersect_decoder = intersection(array({ a: string }), array({ b: number }));
+  const intersect_decoder = 
+    intersection({ x: { a: string }, y: string }
+               , { x: { b: number }, y: string, z: boolean });
 
-  expect<intersection>(intersect_decoder([])).toEqual([]);
   expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
-  expect(intersect_decoder(test_value).map(x => x.a)).toEqual([ '0', '2' ]);
-  expect(intersect_decoder(test_value).map(x => x.b)).toEqual([ 1, 3 ]);
+  expect(() => intersect_decoder({})).toThrow();
 });
-*/
 
 test('intersection of tuple and array', () => {
   const test_value = [ 1, 2 ]

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -736,14 +736,14 @@ test('no intersection for map, set, custom classes', () => {
   const test_value2 = 'test';
 
   type intersection = decodeType<typeof intersect>;
-  const intersect = (result: any) => intersection(_ => result);
+  const intersect = (result: any) => intersection(_ => result, _ => result);
 
   class A extends Map {}
   class B {}
 
   expect<intersection>(intersect(test_value1)(null)).toEqual(test_value1);
   expect<intersection>(intersect(test_value2)(null)).toEqual(test_value2);
-  expect(() => intersect(new A())(null)).toThrow;
-  expect(() => intersect(new B())(null)).toThrow;
-  expect(() => intersect(new Set())(null)).toThrow;
+  expect(() => intersect(new A())(null)).toThrow();
+  expect(() => intersect(new B())(null)).toThrow();
+  expect(() => intersect(new Set())(null)).toThrow();
 })

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -19,6 +19,7 @@ import {
   map,
   dict,
   nullable,
+  intersection,
 } from '../src';
 
 test('homogeneous tuple', () => {
@@ -112,6 +113,39 @@ test('literal literal string union', () => {
   expect<decoderType>(decoder('b')).toEqual('b');
   expect(() => decoder('c')).toThrow();
 });
+
+test('record intersection', () => {
+  type decoderType = decodeType<typeof decoder>;
+  const decoder = intersection(
+    record({a: union('foo', 'bar'), b: nullable(string)}),
+    record({a: union('bar', 'baz'), b: string, c: optional(number)})
+  );
+
+  expect<decoderType>(decoder({a: 'bar', b: 'str'})).toEqual({a: 'bar', b: 'str'});
+  expect(() => decoder({a: 'bar', b: null})).toThrow();
+})
+
+test('union intersection', () => {
+  type decoderType = decodeType<typeof decoder>;
+  const decoder = intersection(
+    union('foo', 'bar', 'baz'),
+    union('bar', 'baz', number),
+    union('baz', boolean, 'foo')
+  )
+
+  expect<decoderType>(decoder('baz')).toEqual('baz');
+  expect(() => decoder('foo')).toThrow();
+})
+
+test('same props intersection', () => {
+  type decoderType = decodeType<typeof decoder>;
+  const decoder = intersection(
+    record({a: string}),
+    record({a: field('a', a => string(a).toUpperCase())}),
+  )
+
+  expect<decoderType>(decoder({a: 'Foo'})).toEqual({a: 'FOO'});
+})
 
 test('decode string', () => {
   const l1: 'a' = 'a' as const;

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -561,7 +561,7 @@ test('intersection fails to override properties', () => {
   expect(() => intersect_decoder({ a: 1 })).toThrow();
 });
 
-test('intersection of objects is additative', () => {
+test('intersection of objects cumulates fields', () => {
   const test_value = { a: 'test', b: 1 };
 
   type intersection = decodeType<typeof intersect_decoder>;
@@ -570,4 +570,73 @@ test('intersection of objects is additative', () => {
   expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
   expect(() => intersect_decoder({ a: '' })).toThrow()
   expect(() => intersect_decoder({ b: 0 })).toThrow()
+});
+
+test('intersection of objects is mixins/multi-inheritance', () => {
+  const test_value = { a: 'test', b: 1 };
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection({ a: string }, { b: number });
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(() => intersect_decoder({ a: '' })).toThrow()
+  expect(() => intersect_decoder({ b: 0 })).toThrow()
+});
+
+test('intersection of empty object', () => {
+  const test_value = { a: 'test' };
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection({}, { a: string });
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(intersect_decoder({ a: '' })).toEqual({ a: '' })
+  expect(() => intersect_decoder({ a: 0 })).toThrow()
+  expect(() => intersect_decoder({ b: '' })).toThrow()
+});
+
+test('intersection of arrays', () => {
+  const test_value = [ 1, 2, 3, ]
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection(array(number), array(number));
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect<intersection>(intersect_decoder([])).toEqual([]);
+  expect(() => intersect_decoder({ a: '' })).toThrow()
+  expect(() => intersect_decoder({ b: 0 })).toThrow()
+});
+
+test('intersection of tuple and array', () => {
+  const test_value = [ 1, 2 ]
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection(tuple(number, number), array(number));
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(() => intersect_decoder([])).toThrow()
+  expect(() => intersect_decoder([ 1, 2, 3, ])).toThrow()
+  expect(() => intersect_decoder({ a: '' })).toThrow()
+  expect(() => intersect_decoder({ b: 0 })).toThrow()
+});
+
+test('intersection of incompatible tuples', () => {
+
+  const intersect_decoder = intersection(tuple(number, number), tuple(string, number));
+
+  expect(() => intersect_decoder([])).toThrow()
+  expect(() => intersect_decoder([ 1, 2 ])).toThrow()
+  expect(() => intersect_decoder([ '1', 2 ])).toThrow()
+  expect(() => intersect_decoder('')).toThrow()
+  expect(() => intersect_decoder(0)).toThrow()
+});
+
+test('intersection of primitives and object fail', () => {
+
+  const intersect_decoder = intersection(number, { a: string });
+
+  expect(() => intersect_decoder([])).toThrow()
+  expect(() => intersect_decoder({})).toThrow()
+  expect(() => intersect_decoder({ a: '' })).toThrow()
+  expect(() => intersect_decoder(1)).toThrow()
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -549,3 +549,25 @@ test('date decoder', () => {
   expect(() => decoder([])).toThrow();
   expect(() => decoder({})).toThrow();
 });
+
+test('intersection fails to override properties', () => {
+  const test_value = { a: 'test' };
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection({ a: number }, { a: string });
+
+  // expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(() => intersect_decoder({ a: '0' })).toThrow();
+  expect(() => intersect_decoder({ a: 1 })).toThrow();
+});
+
+test('intersection of objects is additative', () => {
+  const test_value = { a: 'test', b: 1 };
+
+  type intersection = decodeType<typeof intersect_decoder>;
+  const intersect_decoder = intersection({ a: string }, { a: string, b: number });
+
+  expect<intersection>(intersect_decoder(test_value)).toEqual(test_value);
+  expect(() => intersect_decoder({ a: '' })).toThrow()
+  expect(() => intersect_decoder({ b: 0 })).toThrow()
+});


### PR DESCRIPTION
First of all, thank you for this library, it seems to be exactly what I was hoping to find when I entered "typescript json decoding library" in Google.

I noticed that the library defines union types, but not intersection types, like `a & b`. I've found them quite useful for emulating inheritance.

By taking a look at [this stackoverflow answer](https://stackoverflow.com/a/59463385), I was able to come up with this:

```typescript
// intersectUnion<a | b> = a & b
type intersectUnion<U> = (U extends unknown ? ((_: U) => void) : never) extends ((_: infer I) => void) ? I : never;

// asObject<[a, b]> = { 0: {_: a}, 1: {_: b} }
type asObject<T extends unknown[]> = {[K in Exclude<keyof T, keyof []>]: {_: decodeType<T[K]>}};

// values<{0: a, 1: b}> = a | b
type values<T> = T[keyof T];

// fromObject {_: a} = a
type fromObject<T> = T extends {_: infer V} ? V : never;

// combine helpers to get an intersection of all the item types
type getProductOfDecoderArray<arr extends Decoder<unknown>[]> = fromObject<intersectUnion<values<asObject<arr>>>>;

export const intersection =
  <decoders extends Decoder<unknown>[]>(...decoders: decoders) =>
    (value: Pojo): getProductOfDecoderArray<decoders> => {
      const errors: any[] = [];
      const results: any[] = [];
      for (const decoder of decoders) {
        try {
          results.push(decode(decoder)(value));
        } catch (message) {
          errors.push(message);
        }
      }
      if (errors.length === 0) {
        // When not all cases are objects, the static type checking of the
        // intersection should ensure that we can safely return just the
        // result of the last case
        return results.some(res => typeof res !== 'object')
          ? results[results.length - 1]
          : results.reduce((acc, val) => ({...acc, ...val}), {});
      } else {
        errors.push(`Could not match all of the intersection cases`);
        throw errors.join('\n');
      }
    };
```


Note that if multiple cases create properties with identical keys, only the last one is kept. However, I don't think that's really a problem - after all, `union` has order dependency as well.

The PR includes this change as well as several test cases for it.