### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ const userListDecoder =
 
 Sometimes you need direct access to the fields of the object you're decoding. Maybe you want to use the same fields to calculate two different things, or maybe you want to combine two or more different fields.
 
-The `field` decoder accepts a string, the name of they key, and a decoder which decodes the value found at this key.
+The `field` decoder accepts a string, the name of the key, and a decoder which decodes the value found at this key.
 
 Say you have some date in an iso-date-string format in the field `"dateOfBirth"` but are only interested in the year and month, you could use the `field` decoder to access it in the following way.
 
@@ -320,10 +320,10 @@ const userDecoder = record({
 Alternatively if you need both username and id you can use the `fields` decoder. This has a slightly different api. The `fields` decoder accepts an object decoder in the same way `decoder` does, and a second argument, a continuation, which accepts the result of this decoder and produces the resulting value of the `fields` decoder. An example is maybe more explanatory.
 
 ```typescript
-import { decode, decoder, fields } from 'typescript-json-decoder';
+import { decodeType, record, fields } from 'typescript-json-decoder';
 
-type User = decode<typeof userDecoder>;
-const userDecoder = decoder({
+type User = decodeType<typeof userDecoder>;
+const userDecoder = record({
     identifier: fields({ username: string, userId: number },
                             ({ username, userId }) => `user:${username}:${userid}`),
 });

--- a/article.md
+++ b/article.md
@@ -29,7 +29,7 @@ Check out [the GitHub page](https://github.com/tskj/typescript-json-decoder) to 
 Let me give you a basic introduction to the underlying idea. If we wanted to replace our `User` type with a decoder for that type, we would instead write the following.
 
 ```typescript
-import { decodeType, record, number, string, array } from 'typescript-json-decoder`;
+import { decodeType, record, number, string, array } from 'typescript-json-decoder';
 
 type User = decodeType<typeof userDecoder>;
 const userDecoder = record({
@@ -77,7 +77,7 @@ If you think about it, a decoder by necessity does not have the same type as the
 However, let's ignore that and first think about how to extract the type that a (function) decoder will decode.
 
 ```typescript
-type decoeType<decoder> = decoder extends (x: Pojo) => (infer T) ? T : never;
+type decodeType<decoder> = decoder extends (x: Pojo) => (infer T) ? T : never;
 ```
 
 Now this is the kind of metaprogramming that gets me going. What in the world is going on. Well, first of all we have a ternary - essentially an if test on types. The thing we are testing on is the `decoder extends (x: Pojo) => (infer T)` part, which is a *subtype test*. The extend keyword, I think, is a horribly chosen name in TypeScript, mostly carried over from other contexts. What it means is "is a subtype of". It is a question asked of the type parameter `decoder`, are you a subtype of the type `(x: Pojo) => (infer T)`? Which begs the question, what is `infer T`? Well, it is whatever it needs to be to satisfy the subtype test. If `decoder` is the function type defined above, `(x: Pojo) => User`, then `T` would need to be `User` for the one to be the subtype of the other - at least if you consider being the same type as being a subtype. The keyword `infer` is used to introduce a new type variable. In the first branch of the ternary we return the type `T` if we have a match (that is, the decoder is a function type), and in the second branch we return TypeScript's bottom type `never`, indicating this should never happen. If this does happen, and we try to use the resulting `never` type for anything, we get a compiler error. `never` is the empty set, if you are inclined to think about types as sets. There is no value of this type.


### PR DESCRIPTION
I noticed some typos while reading through the markdown files.