### PR TITLE
Add decoder for having a dict with type as keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-json-decoder",
-  "version": "1.0.6",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-json-decoder",
-      "version": "1.0.6",
+      "version": "1.0.10",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.4.0",

--- a/src/higher-order-decoders.ts
+++ b/src/higher-order-decoders.ts
@@ -241,7 +241,7 @@ export const dict =
   };
 
 export const dictWithTypedKey =
-  <K, D extends Decoder<unknown>>(
+  <K, D extends Decoder<unknown> = Decoder<unknown>>(
     decoder: D,
     keys: ReadonlyArray<K>,
   ): DecoderFunction<Map<K, decodeType<D>>> =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
   set,
   map,
   dict,
+  dictWithTypedKey,
   nullable,
 } from './higher-order-decoders';
 export {

--- a/src/pojo.ts
+++ b/src/pojo.ts
@@ -29,3 +29,7 @@ export function assert_is_pojo(value: unknown): asserts value is Pojo {
     throw `Value \`${value}\` is not a type that can be parsed by this library. Only primitive JS values and regular JS objects or arrays can be parsed, not classes (think anything that is valid JSON).`;
   }
 }
+
+export function isKey<K>(value: unknown, keys: ReadonlyArray<K>): value is K {
+  return keys.includes(value as any);
+}

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -21,6 +21,7 @@ import {
   nullable,
   intersection,
   Decoder,
+  dictWithTypedKey,
 } from '../src';
 
 test('homogeneous tuple', () => {
@@ -457,6 +458,27 @@ test('dict decoder', () => {
       ['two', 2],
     ]),
   );
+});
+
+test('dict decoder with typed key', () => {
+  const l1 = { small: true, medium: false };
+  const l2 = { xlarge: true, small: false };
+
+  const SizeValues = ['small', 'medium', 'large'] as const;
+
+  type dict_with_typed_keys = decodeType<typeof dict_with_typed_keys_decoder>;
+  const dict_with_typed_keys_decoder = dictWithTypedKey(boolean, SizeValues);
+
+  expect<dict_with_typed_keys>(dict_with_typed_keys_decoder({})).toEqual(
+    new Map(),
+  );
+  expect<dict_with_typed_keys>(dict_with_typed_keys_decoder(l1)).toEqual(
+    new Map([
+      ['small', true],
+      ['medium', false],
+    ]),
+  );
+  expect(() => dict_with_typed_keys_decoder(l2)).toThrow();
 });
 
 test('nullable decoder', () => {

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -23,7 +23,6 @@ import {
   Decoder,
   dictWithTypedKey,
 } from '../src';
-import { dictWithTypedKey } from '../src/higher-order-decoders';
 
 test('homogeneous tuple', () => {
   const t: [string, string] = ['a', 'b'];

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -22,6 +22,7 @@ import {
   intersection,
   Decoder,
 } from '../src';
+import { dictWithTypedKey } from '../src/higher-order-decoders';
 
 test('homogeneous tuple', () => {
   const t: [string, string] = ['a', 'b'];
@@ -457,6 +458,27 @@ test('dict decoder', () => {
       ['two', 2],
     ]),
   );
+});
+
+test('dict decoder with typed key', () => {
+  const l1 = { small: true, medium: false };
+  const l2 = { xlarge: true, small: false };
+
+  const SizeValues = ['small', 'medium', 'large'] as const;
+
+  type dict_with_typed_keys = decodeType<typeof dict_with_typed_keys_decoder>;
+  const dict_with_typed_keys_decoder = dictWithTypedKey(boolean, SizeValues);
+
+  expect<dict_with_typed_keys>(dict_with_typed_keys_decoder({})).toEqual(
+    new Map(),
+  );
+  expect<dict_with_typed_keys>(dict_with_typed_keys_decoder(l1)).toEqual(
+    new Map([
+      ['small', true],
+      ['medium', false],
+    ]),
+  );
+  expect(() => dict_with_typed_keys_decoder(l2)).toThrow();
 });
 
 test('nullable decoder', () => {


### PR DESCRIPTION
Hello, here is the pull request we talked about in #19 (this PR closes #19).

But I think we should discuss some things before merging:

First of all I added a new decoder since I didn't know if you wanted me to do that or extend the current dict decoder. But I can extend the current one if you want. And just make the keys argument optional.

Secondly I can't seem to get the default value for `D extends Decoder<unknown>` that we discussed about in the issue to work.
If I put this in the generic parameter: `D extends Decoder<unknown> = Decoder<unknown>`
And we give a type to `K` and not to `D`. And we do this:
```ts
export const SizeValues = ['small', 'medium', 'large'] as const;
type Sizes = typeof SizeValues[number];

const dictDecoder = dictWithTypedKey<Sizes>(boolean, SizeValues);

type DictDecoder = decodeType<typeof dictDecoder>
```
And then hover `DictDecoder`, it says the type is `Map<"small" | "medium" | "large", unknown>`.

If we remove the assignment in the generic parameters and do this:
```ts
const SizeValues = ['small', 'medium', 'large'] as const;
type Sizes = typeof SizeValues[number];

const dictDecoder = dictWithTypedKey(boolean, SizeValues);

type DictDecoder = decodeType<typeof dictDecoder>
```
Then the type `DictDecoder` is inferred correctly to `Map<"small" | "medium" | "large", boolean>`.

I'm fine with merging the decoder without inferring the generic `D` however it would be nice if we could find a way..
Because if we can do it and we do this:
```ts
const ExtraSizeValues = ['xlarge', 'schmedium'] as const;

const SizeValues = ['small', 'medium', 'large'] as const;
type Sizes = typeof SizeValues[number];

const dictDecoder = dictWithTypedKey<Sizes>(boolean, ExtraSizeValues);
```

We get this nice error in code:
```
Argument of type 'readonly ["xlarge", "schmedium"]' is not assignable to parameter of type 'readonly ("small" | "medium" | "large")[]'.
  Type '"xlarge" | "schmedium"' is not assignable to type '"small" | "medium" | "large"'.
    Type '"xlarge"' is not assignable to type '"small" | "medium" | "large"'. Did you mean '"large"'?
```

Let me know if we should do some more tests!